### PR TITLE
Add Notes component with local storage persistence

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import SearchBar from './components/SearchBar';
 import Dashboard from './components/Dashboard';
 import ResponseBuilder from './components/ResponseBuilder';
 import DailyTip from './components/DailyTip';
+import Notes from './components/Notes';
 import issuesData from './data/issues.json';
 
 export default function App() {
@@ -40,6 +41,10 @@ export default function App() {
 
       <section style={{ marginTop: 8 }}>
         <ResponseBuilder selectedIssue={selectedIssue} />
+      </section>
+
+      <section style={{ marginTop: 8 }}>
+        <Notes />
       </section>
     </div>
   );

--- a/src/components/Notes.jsx
+++ b/src/components/Notes.jsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'compass-notes';
+
+export default function Notes() {
+  const [notes, setNotes] = useState('');
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      if (stored !== null) {
+        setNotes(stored);
+      }
+    } catch (error) {
+      // Ignore localStorage access issues.
+    }
+  }, []);
+
+  const handleChange = (event) => {
+    const nextNotes = event.target.value;
+    setNotes(nextNotes);
+
+    try {
+      window.localStorage.setItem(STORAGE_KEY, nextNotes);
+    } catch (error) {
+      // Ignore write errors.
+    }
+  };
+
+  return (
+    <section style={{ marginTop: 24 }}>
+      <label htmlFor="compass-notes" style={{ display: 'block', fontWeight: 600, marginBottom: 8 }}>
+        Notes
+      </label>
+      <textarea
+        id="compass-notes"
+        value={notes}
+        onChange={handleChange}
+        rows={6}
+        style={{
+          width: '100%',
+          padding: 12,
+          fontSize: '1rem',
+          fontFamily: 'inherit',
+          borderRadius: 8,
+          border: '1px solid #ccc',
+          resize: 'vertical'
+        }}
+        placeholder="Jot down reminders, next steps, or insights here..."
+      />
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a Notes component that loads and persists text with the `compass-notes` localStorage key
- provide a labeled textarea for jotting down reminders and styling consistent with the app
- render the Notes section at the bottom of the main App layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68ce9e02121883279d44e28b60e79c9e