### PR TITLE
Replace inline styles with shared stylesheet

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import ResponseBuilder from './components/ResponseBuilder';
 import DailyTip from './components/DailyTip';
 import Notes from './components/Notes';
 import issuesData from './data/issues.json';
+import './styles.css';
 
 export default function App() {
   const [query, setQuery] = useState("");
@@ -22,28 +23,28 @@ export default function App() {
   );
 
   return (
-    <div style={{ maxWidth: "980px", margin: "auto", padding: "24px", fontFamily: "system-ui, Arial, sans-serif" }}>
-      <header style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12 }}>
-        <h1 style={{ margin: 0 }}>Classroom Compass</h1>
+    <div className="app-container">
+      <header className="app-header">
+        <h1 className="app-title">Classroom Compass</h1>
       </header>
 
-      <section style={{ marginTop: 16 }}>
+      <section className="section">
         <DailyTip />
       </section>
 
-      <section style={{ marginTop: 16 }}>
+      <section className="section">
         <SearchBar query={query} setQuery={setQuery} />
       </section>
 
-      <section style={{ marginTop: 8 }}>
+      <section className="section section-tight">
         <Dashboard issues={filtered} onSelect={setSelectedIssue} />
       </section>
 
-      <section style={{ marginTop: 8 }}>
+      <section className="section section-tight">
         <ResponseBuilder selectedIssue={selectedIssue} />
       </section>
 
-      <section style={{ marginTop: 8 }}>
+      <section className="section section-tight">
         <Notes />
       </section>
     </div>

--- a/src/components/DailyTip.jsx
+++ b/src/components/DailyTip.jsx
@@ -9,15 +9,9 @@ export default function DailyTip() {
   const randomStrategy = allStrategies[Math.floor(Math.random() * allStrategies.length)];
 
   return (
-    <div style={{ 
-      padding: 16, 
-      border: "1px solid #e5e7eb", 
-      borderRadius: 12, 
-      background: "#f9fafb",
-      boxShadow: "0 1px 2px rgba(0,0,0,0.05)"
-    }}>
-      <h3 style={{ margin: "0 0 8px 0", fontSize: 16, color: "#374151" }}>Daily tip</h3>
-      <p style={{ margin: 0, color: "#4b5563", fontSize: 14 }}>{randomStrategy}</p>
+    <div className="card card-muted">
+      <h3 className="daily-tip-heading">Daily tip</h3>
+      <p className="daily-tip-text">{randomStrategy}</p>
     </div>
   );
 }

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -4,11 +4,7 @@ import IssueTile from './IssueTile';
 
 export default function Dashboard({ issues, onSelect }) {
   return (
-    <div style={{
-      display: "grid",
-      gridTemplateColumns: "repeat(auto-fill, minmax(250px, 1fr))",
-      gap: 8
-    }}>
+    <div className="issues-grid">
       {issues.map(issue => (
         <IssueTile key={issue.id} issue={issue} onSelect={onSelect} />
       ))}

--- a/src/components/IssueTile.jsx
+++ b/src/components/IssueTile.jsx
@@ -5,20 +5,11 @@ export default function IssueTile({ issue, onSelect }) {
   return (
     <button
       onClick={() => onSelect(issue)}
-      style={{
-        textAlign: "left",
-        border: "1px solid #e5e7eb",
-        borderRadius: 12,
-        padding: 16,
-        margin: 8,
-        background: "white",
-        cursor: "pointer",
-        boxShadow: "0 1px 2px rgba(0,0,0,0.05)"
-      }}
+      className="card issue-tile"
       aria-label={`Open strategies for ${issue.title}`}
     >
-      <h3 style={{ margin: "0 0 6px 0", fontSize: 18 }}>{issue.title}</h3>
-      <p style={{ margin: 0, color: "#4b5563" }}>{issue.description}</p>
+      <h3 className="issue-tile-title">{issue.title}</h3>
+      <p className="issue-tile-description">{issue.description}</p>
     </button>
   );
 }

--- a/src/components/Notes.jsx
+++ b/src/components/Notes.jsx
@@ -28,8 +28,8 @@ export default function Notes() {
   };
 
   return (
-    <section style={{ marginTop: 24 }}>
-      <label htmlFor="compass-notes" style={{ display: 'block', fontWeight: 600, marginBottom: 8 }}>
+    <section className="section section-spacious">
+      <label htmlFor="compass-notes" className="notes-label">
         Notes
       </label>
       <textarea
@@ -37,15 +37,7 @@ export default function Notes() {
         value={notes}
         onChange={handleChange}
         rows={6}
-        style={{
-          width: '100%',
-          padding: 12,
-          fontSize: '1rem',
-          fontFamily: 'inherit',
-          borderRadius: 8,
-          border: '1px solid #ccc',
-          resize: 'vertical'
-        }}
+        className="notes-textarea"
         placeholder="Jot down reminders, next steps, or insights here..."
       />
     </section>

--- a/src/components/ResponseBuilder.jsx
+++ b/src/components/ResponseBuilder.jsx
@@ -4,15 +4,15 @@ import React from 'react';
 export default function ResponseBuilder({ selectedIssue }) {
   if (!selectedIssue) {
     return (
-      <div style={{ padding: 16, border: "1px dashed #cbd5e1", borderRadius: 12, color: "#475569" }}>
+      <div className="card placeholder-card">
         Select an issue above to view scaffolded strategies.
       </div>
     );
   }
 
   return (
-    <div style={{ padding: 16, border: "1px solid #e5e7eb", borderRadius: 12, marginTop: 8 }}>
-      <h2 style={{ marginTop: 0 }}>Strategies for “{selectedIssue.title}”</h2>
+    <div className="card">
+      <h2 className="response-heading">Strategies for “{selectedIssue.title}”</h2>
       <ul>
         {selectedIssue.strategies.map((s, idx) => (
           <li key={idx}>{s}</li>

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -8,13 +8,7 @@ export default function SearchBar({ query, setQuery }) {
       placeholder="Search issues..."
       value={query}
       onChange={e => setQuery(e.target.value)}
-      style={{
-        padding: "10px 12px",
-        width: "100%",
-        border: "1px solid #ddd",
-        borderRadius: 8,
-        fontSize: 16
-      }}
+      className="search-input"
     />
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,114 @@
+.app-container {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 24px;
+  font-family: system-ui, Arial, sans-serif;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.app-title {
+  margin: 0;
+}
+
+.section {
+  margin-top: 16px;
+}
+
+.section-tight {
+  margin-top: 8px;
+}
+
+.section-spacious {
+  margin-top: 24px;
+}
+
+.card {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 16px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  background-color: #ffffff;
+}
+
+.card-muted {
+  background-color: #f9fafb;
+}
+
+.placeholder-card {
+  border-style: dashed;
+  border-color: #cbd5e1;
+  box-shadow: none;
+  color: #475569;
+}
+
+.issues-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 8px;
+}
+
+.issue-tile {
+  text-align: left;
+  cursor: pointer;
+  margin: 8px;
+  background-color: #ffffff;
+  font: inherit;
+}
+
+.issue-tile-title {
+  margin: 0 0 6px;
+  font-size: 18px;
+}
+
+.issue-tile-description {
+  margin: 0;
+  color: #4b5563;
+}
+
+.daily-tip-heading {
+  margin: 0 0 8px;
+  font-size: 16px;
+  color: #374151;
+}
+
+.daily-tip-text {
+  margin: 0;
+  color: #4b5563;
+  font-size: 14px;
+}
+
+.search-input {
+  padding: 10px 12px;
+  width: 100%;
+  border: 1px solid #dddddd;
+  border-radius: 8px;
+  font-size: 16px;
+  box-sizing: border-box;
+}
+
+.notes-label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.notes-textarea {
+  width: 100%;
+  padding: 12px;
+  font-size: 1rem;
+  font-family: inherit;
+  border-radius: 8px;
+  border: 1px solid #cccccc;
+  resize: vertical;
+  box-sizing: border-box;
+}
+
+.response-heading {
+  margin-top: 0;
+}


### PR DESCRIPTION
## Summary
- add a shared `src/styles.css` file with layout, spacing, and card helper classes
- update App and feature components to replace inline styles with class names that use the shared stylesheet

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68ce9f0efbe48327852a74f3a59adc3b