### PR TITLE
Add Off-task Behavior issue entry

### DIFF
--- a/src/data/issues.json
+++ b/src/data/issues.json
@@ -28,5 +28,16 @@
       "Use a countdown and positive narration of students meeting expectations.",
       "Reset and retry brief parts of the transition if needed."
     ]
+  },
+  {
+    "id": 4,
+    "title": "Off-task Behavior",
+    "description": "Student is distracted or not attending to the assigned task.",
+    "strategies": [
+      "Provide a clear, time-bound goal and check back promptly.",
+      "Use proximity or gentle touchpoint to re-engage attention.",
+      "Offer a brief choice in how to start or complete the task.",
+      "Acknowledge and reinforce the first sign of on-task effort."
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- add an Off-task Behavior entry to the issues data with four actionable strategies

## Testing
- not run (data-only change)


------
https://chatgpt.com/codex/tasks/task_b_68cea076919c8327a0a603868aee60c0