### PR TITLE
Fix gh-pages deploy permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,8 @@ on:
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- grant the gh-pages workflow explicit permissions to push built assets

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68cea4c6f264832789c62c3cec6713fc